### PR TITLE
Check if dns is not None before iterating on it

### DIFF
--- a/src/dockerbot/docker.py
+++ b/src/dockerbot/docker.py
@@ -98,8 +98,9 @@ class Client(object):
             pre.extend(['-H', host])
         if remove:
             post.append('--rm')
-        for addr in dns:
-            post.extend(('--dns', addr))
+        if dns is not None:
+            for addr in dns:
+                post.extend(('--dns', addr))
         for volume in volumes:
             post.extend(('-v', volume))
         for volume in extra_volumes:


### PR DESCRIPTION
When the user doesn't specify any dns, (i.e. by removing the field in the dockerbot.yml) __to_flags function is called with dns=None even if the default value for dns is [].